### PR TITLE
Allow users to determine karma versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,5 @@
     "karma-jasmine": "~0.1.5",
     "karma-phantomjs-launcher": "~0.1.4",
     "load-grunt-tasks": "~0.6.0"
-  },
-  "peerDependencies": {
-    "karma": "^0.12.23"
   }
 }


### PR DESCRIPTION
Removes the `peerDependencies` to allow for users to set the version of Karma in which to run.
